### PR TITLE
feat: implemented client side based kv expiry for natsprovier

### DIFF
--- a/provider/natsprovider/nats.go
+++ b/provider/natsprovider/nats.go
@@ -2,11 +2,17 @@ package natsprovider
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/driftdev/polycache-go"
 	"github.com/driftdev/polycache-go/pcerror"
 	"github.com/nats-io/nats.go"
 	"time"
 )
+
+type data struct {
+	Value      string    `json:"value"`
+	Expiration time.Time `json:"expiration"`
+}
 
 type NATSProvider struct {
 	client nats.KeyValue
@@ -19,7 +25,22 @@ func New(client nats.KeyValue) polycache.IPolyCache {
 }
 
 func (np *NATSProvider) Set(ctx context.Context, key string, value string, expiry time.Duration) error {
-	_, err := np.client.PutString(key, value)
+	var expiration time.Time
+	if expiry != 0 {
+		expiration = time.Now().Add(expiry)
+	}
+
+	d := data{
+		Value:      value,
+		Expiration: expiration,
+	}
+
+	dataBytes, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = np.client.Put(key, dataBytes)
 	if err != nil {
 		return err
 	}
@@ -37,7 +58,21 @@ func (np *NATSProvider) Get(ctx context.Context, key string) (string, error) {
 		return "", pcerror.PolyCacheErrorValueNotFound
 	}
 
-	return string(result.Value()), nil
+	var resultData data
+	err = json.Unmarshal(result.Value(), &resultData)
+	if err != nil {
+		return "", err
+	}
+
+	if !resultData.Expiration.IsZero() && time.Now().After(resultData.Expiration) {
+		err := np.client.Delete(key)
+		if err != nil {
+			return "", err
+		}
+		return "", pcerror.PolyCacheErrorValueNotFound
+	}
+
+	return resultData.Value, nil
 }
 
 func (np *NATSProvider) Delete(ctx context.Context, key string) error {


### PR DESCRIPTION
## Motivation

NATS KV currently doesn't have built in per key based expiration. So to fix the key expiration issue the natsprovider implements a get and expire strategy on the client level. 

## Implementation

The expiration and value are serialized to a data object and persisted to NATS KV as a single object using Set. When get operation is done We deserialize the object and check if the value is expired using the expiration field if its expired the value is deleted then the Get operation and returns value not found error else if the not expired the value is returned  